### PR TITLE
Fix DVM_BIN/DVM_DIR Typo on install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ add_nvm_into_rc_file() {
   echo "
 # Deno Version Manager
 export DVM_DIR=\"\$HOME/.dvm\"
-export PATH=\"\$PATH:\$DVM_BIN\"
+export PATH=\"\$PATH:\$DVM_DIR\"
 [ -f \"\$DVM_DIR/dvm.sh\" ] && $cmd_declaration\"\$DVM_DIR/dvm.sh\"
 [ -f \"\$DVM_DIR/bash_completion\" ] && . \"\$DVM_DIR/bash_completion\"
 " >> "$DVM_RC_FILE"


### PR DESCRIPTION
This made it so the `deno` binary wasn't available. I suppose it was some sort of typo that didn't always exist as I just had this on a recent fresh install.