### PR TITLE
Fix logic typo - dvm_extract_file should expect to succeed, not fail.

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -1178,7 +1178,7 @@ export DVM_VERSION="v0.8.1"
       dvm_print "Installing deno $version from cache..."
     fi
 
-    ! dvm_extract_file "$version"
+    dvm_extract_file "$version"
   }
 
   # Download the source code of Deno from the network, and try to building the


### PR DESCRIPTION
https://github.com/ghosind/dvm/blob/bb103932e3378fb4be8f6b0015b9e5cd2feef587/dvm.sh#L1056

That line should be `dvm_extract_file "$version"` and not inverted with `!`

Previously the `! dvm_extract_file "$version"` was using `!` because it's in an if guard for an early return. https://github.com/ghosind/dvm/blob/ea31eac8ba65f101f8062c2838ee903df9b07031/dvm.sh#L1010