### PR TITLE
Fetch the latest version and download Deno binary file from dl.deno.land (#33)

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -992,7 +992,7 @@ export DVM_VERSION="v0.8.3"
 
     dvm_print "\ntry to getting deno latest version ..."
 
-    latest_url="https://api.github.com/repos/denoland/deno/releases/latest"
+    latest_url="https://dl.deno.land/release-latest.txt"
 
     if ! dvm_request "$latest_url"
     then
@@ -1001,7 +1001,7 @@ export DVM_VERSION="v0.8.3"
       return
     fi
 
-    tag_name=$(echo "$DVM_REQUEST_RESPONSE" | sed 's/"/\n/g' | grep tag_name -A 2 | grep v)
+    tag_name="$DVM_REQUEST_RESPONSE"
 
     if [ -z "$tag_name" ]
     then

--- a/dvm.sh
+++ b/dvm.sh
@@ -892,6 +892,7 @@ export DVM_VERSION="v0.8.3"
     local version
     local url
     local temp_file
+    local registry
 
     version="$1"
 
@@ -902,12 +903,19 @@ export DVM_VERSION="v0.8.3"
 
     if [ -z "$DVM_INSTALL_REGISTRY" ]
     then
-      DVM_INSTALL_REGISTRY="https://github.com/denoland/deno/releases/download"
+      if ! [[ "$version" < "v1.0.1" ]] || [[ "$version" = "v1.0.0" ]]
+      then
+        registry="https://dl.deno.land/release"
+      else
+        registry="https://github.com/denoland/deno/releases/download"
+      fi
+    else
+      registry="$DVM_INSTALL_REGISTRY"
     fi
 
-    dvm_debug "regitry url: $DVM_INSTALL_REGISTRY"
+    dvm_debug "regitry url: $registry"
 
-    url="$DVM_INSTALL_REGISTRY/$version/$DVM_TARGET_NAME"
+    url="$registry/$version/$DVM_TARGET_NAME"
     temp_file="$DVM_DIR/download/$version/deno-downloading.$DVM_TARGET_TYPE"
 
     if dvm_download_file "$url" "$temp_file"


### PR DESCRIPTION
This change fetches the latest Deno version from `dl.deno.land/release-latest.txt` and downloads the binary file from `dl.deno.land` if the version is v1.0.0 or above.

For #33 