### PR TITLE
Add SHA256 checksum support

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -196,6 +196,7 @@ DVM支持的命令包括有：
 | | `dvm install <version> --skip-validation` | 下载deno前不对版本进行校验 |
 | | `dvm install <version> --from-source` | 编译源码并安装Deno |
 | | `dvm install <version> --skip-download-cache` | 不使用已下载的文件，重新下载并安装 |
+| | `dvm install <version> --sha256sum` | 下载安装Deno，并进行sha256校验 |
 | `uninstall` | `dvm uninstall <version>` | 卸载指定的版本 |
 | `use` | `dvm use` | 将指定的版本设置为当前使用的版本，未指定版本将从当前目录下的`.dvmrc`文件中读取 |
 | | `dvm use <version>` | 将指定的版本设置为当前使用的版本 |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ DVM supported the following commands:
 | | `dvm install <version> --skip-validation` | Do not validate deno version before trying to download it. |
 | | `dvm install <version> --from-source` | Build and install Deno from source code. |
 | | `dvm install <version> --skip-download-cache` | Download and install Deno without using downloaded cache. |
+| | `dvm install <version> --sha256sum` | Download and install Deno with sha256sum check. |
 | `uninstall` | `dvm uninstall <version>` | Uninstall the specified version. |
 | `use` | `dvm use` | Use the specified version read from .dvmrc. |
 | | `dvm use <version>` | Use the specified version that passed by argument. |

--- a/bash_completion
+++ b/bash_completion
@@ -53,7 +53,7 @@ _dvm_add_exclusive_option() {
 # Add options for command install.
 _dvm_add_install_option() {
   _dvm_add_exclusive_option "--from-binary" "--from-source"
-  _dvm_add_options "--registry=" "--skip-validation" "--skip-download-cache"
+  _dvm_add_options "--registry=" "--skip-validation" "--skip-download-cache" "--sha256sum"
 }
 
 # Add the specified option to the options list.

--- a/dvm.sh
+++ b/dvm.sh
@@ -165,16 +165,18 @@ export DVM_VERSION="v0.9.1"
       local url
       local file
       local cmd
+      local downloading_file
 
       url="$1"
       file="$2"
+      downloading_file="$file.downloading"
 
       dvm_debug "downloading url: $url"
       dvm_debug "download destination file: $file"
 
       if dvm_has curl
       then
-        cmd="curl -LJ $url -o $file"
+        cmd="curl -LJ $url -o $downloading_file"
         if [ "$DVM_QUIET_MODE" = true ]
         then
           cmd="$cmd -s"
@@ -192,8 +194,14 @@ export DVM_VERSION="v0.9.1"
 
       if ! eval "$cmd"
       then
+        # remove failed download file
+        rm -f "$downloading_file"
         dvm_failure
+        return
       fi
+
+      # rename the downloading file to the target file
+      mv "$downloading_file" "$file"
     }
 
     # Send a GET request to the specific url, and save response to the
@@ -974,7 +982,7 @@ export DVM_VERSION="v0.9.1"
     dvm_debug "registry url: $registry"
 
     url="$registry/$version/$DVM_TARGET_NAME"
-    temp_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME.downloading"
+    temp_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME"
 
     if dvm_download_file "$url" "$temp_file"
     then

--- a/dvm.sh
+++ b/dvm.sh
@@ -1416,7 +1416,7 @@ export DVM_VERSION="v0.9.1"
     local download_file
 
     version="$1"
-    download_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME.downloading"
+    download_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME"
 
     if [[ $file_type == *"$DVM_FILE_TYPE"* ]]
     then

--- a/dvm.sh
+++ b/dvm.sh
@@ -582,15 +582,7 @@ export DVM_VERSION="v0.9.1"
         continue
       fi
 
-      [ -f "$cache_path/deno-downloading.zip" ] && rm "$cache_path/deno-downloading.zip"
-
-      [ -f "$cache_path/deno-downloading.gz" ] && rm "$cache_path/deno-downloading.gz"
-
-      [ -f "$cache_path/deno.zip" ] && rm "$cache_path/deno.zip"
-
-      [ -f "$cache_path/deno.gz" ] && rm "$cache_path/deno.gz"
-
-      rmdir "$cache_path"
+      rm -rf "$cache_path"
     done
   }
 }

--- a/dvm.sh
+++ b/dvm.sh
@@ -60,7 +60,6 @@ export DVM_VERSION="v0.9.1"
 
       # Set global variables to default values
       DVM_DENO_VERSION=""
-      DVM_FILE_TYPE=""
       DVM_INSTALL_MODE="binary"
       DVM_INSTALL_REGISTRY=""
       DVM_INSTALL_SKIP_VALIDATION=false
@@ -987,9 +986,6 @@ export DVM_VERSION="v0.9.1"
 
     if dvm_download_file "$url" "$temp_file"
     then
-      local file_type
-      file_type=$(file "$temp_file")
-
       if dvm_validate_download_file "$version" "$url"
       then
         return
@@ -1117,10 +1113,8 @@ export DVM_VERSION="v0.9.1"
     if dvm_compare_version "$target_version" "v0.36.0"
     then
       DVM_TARGET_TYPE="gz"
-      DVM_FILE_TYPE="gzip compressed data"
     else
       DVM_TARGET_TYPE="zip"
-      DVM_FILE_TYPE="Zip archive data"
     fi
 
     dvm_debug "target file type: $DVM_TARGET_TYPE"
@@ -1424,13 +1418,6 @@ export DVM_VERSION="v0.9.1"
     download_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME"
     sha256sum_url="$2.sha256sum"
     sha256sum_file="$download_file.sha256sum"
-
-    if [[ $file_type != *"$DVM_FILE_TYPE"* ]]
-    then
-      dvm_print_error "Unmatched file type: $file_type"
-      dvm_failure
-      return
-    fi
 
     if [ "$DVM_INSTALL_SHA256SUM" = true ] && dvm_has sha256sum
     then
@@ -1762,7 +1749,7 @@ export DVM_VERSION="v0.9.1"
     echo "$content" > "$DVM_PROFILE_FILE"
 
     # unset global variables
-    unset -v DVM_COLOR_MODE DVM_DENO_VERSION DVM_DIR DVM_FILE_TYPE DVM_INSTALL_MODE \
+    unset -v DVM_COLOR_MODE DVM_DENO_VERSION DVM_DIR DVM_INSTALL_MODE \
       DVM_INSTALL_REGISTRY DVM_INSTALL_SHA256SUM DVM_INSTALL_SKIP_CACHE \
       DVM_INSTALL_SKIP_VALIDATION DVM_LATEST_VERSION DVM_PROFILE_FILE DVM_QUIET_MODE \
       DVM_REMOTE_VERSIONS DVM_REQUEST_RESPONSE DVM_SOURCE DVM_TARGET_ARCH \

--- a/dvm.sh
+++ b/dvm.sh
@@ -1419,7 +1419,9 @@ export DVM_VERSION="v0.9.1"
     sha256sum_url="$2.sha256sum"
     sha256sum_file="$download_file.sha256sum"
 
-    if [ "$DVM_INSTALL_SHA256SUM" = true ] && dvm_has sha256sum
+    if [ "$DVM_INSTALL_SHA256SUM" = true ] &&
+      dvm_has shasum &&
+      ! dvm_compare_version "$version" "v2.0.0"
     then
       dvm_debug "downloading sha256sum file: $sha256sum_url"
 
@@ -1431,7 +1433,7 @@ export DVM_VERSION="v0.9.1"
       fi
 
       dvm_print "Computing checksum with sha256sum..."
-      checksum=$(sha256sum "$download_file" | cut -d " " -f 1)
+      checksum=$(shasum -a 256 "$download_file" | cut -d " " -f 1)
       checksum_expected=$(cut -d " " -f 1 < "$sha256sum_file" )
       dvm_debug "checksum: $checksum, expected checksum: $checksum_expected"
 

--- a/dvm.sh
+++ b/dvm.sh
@@ -1400,6 +1400,7 @@ export DVM_VERSION="v0.9.1"
   # - $1: The Deno version to install.
   dvm_validate_download_file() {
     local version
+    local download_url
     local download_file
     local sha256sum_url
     local sha256sum_file
@@ -1407,13 +1408,15 @@ export DVM_VERSION="v0.9.1"
     local checksum_expected
 
     version="$1"
+    download_url="$2"
+
     download_file="$DVM_DIR/download/$version/$DVM_TARGET_NAME"
-    sha256sum_url="$2.sha256sum"
+    sha256sum_url="$download_url.sha256sum"
     sha256sum_file="$download_file.sha256sum"
 
     if [ "$DVM_INSTALL_SHA256SUM" = true ] &&
       dvm_has shasum &&
-      ! dvm_compare_version "$version" "v2.0.0"
+      ! dvm_compare_version "$version" "v2.0.1"
     then
       dvm_debug "downloading sha256sum file: $sha256sum_url"
 

--- a/test/test_install_version.sh
+++ b/test/test_install_version.sh
@@ -8,8 +8,8 @@ dvm_test_error() {
 # shellcheck disable=SC1091
 \. ./dvm.sh || dvm_test_error "failed to install dvm"
 
-# Install deno v2.0.0
-TARGET_VERSION="2.0.0"
+# Install deno v2.2.0
+TARGET_VERSION="2.2.0"
 dvm install "v$TARGET_VERSION" --skip-validation --sha256sum || dvm_test_error "run 'dvm install v$TARGET_VERSION' failed"
 
 # Check installed version directory

--- a/test/test_install_version.sh
+++ b/test/test_install_version.sh
@@ -10,7 +10,7 @@ dvm_test_error() {
 
 # Install deno v1.0.0
 TARGET_VERSION="1.45.0"
-dvm install "v$TARGET_VERSION" --skip-validation || dvm_test_error "run 'dvm install v$TARGET_VERSION' failed"
+dvm install "v$TARGET_VERSION" --skip-validation --sha256sum || dvm_test_error "run 'dvm install v$TARGET_VERSION' failed"
 
 # Check installed version directory
 [ -d "$DVM_DIR/versions/v$TARGET_VERSION" ] || dvm_test_error "'$DVM_DIR/versions/v$TARGET_VERSION' is not a directory"

--- a/test/test_install_version.sh
+++ b/test/test_install_version.sh
@@ -8,8 +8,8 @@ dvm_test_error() {
 # shellcheck disable=SC1091
 \. ./dvm.sh || dvm_test_error "failed to install dvm"
 
-# Install deno v1.0.0
-TARGET_VERSION="1.45.0"
+# Install deno v2.0.0
+TARGET_VERSION="2.0.0"
 dvm install "v$TARGET_VERSION" --skip-validation --sha256sum || dvm_test_error "run 'dvm install v$TARGET_VERSION' failed"
 
 # Check installed version directory


### PR DESCRIPTION
Add SHA256 checksum support for Deno v2.0.1 and later versions, enabling the feature with `--sha256sum` option.

For #44 